### PR TITLE
20210304 goods ranking by category add

### DIFF
--- a/ec/app/Http/Controllers/GoodRankingController.php
+++ b/ec/app/Http/Controllers/GoodRankingController.php
@@ -31,12 +31,12 @@ class GoodRankingController extends Controller
     public function goodRanking()
     {
         // 商品ランキングを返します
-        // if (Cache::has('purchaseHistoryRanking')) {
-        //     return json_encode(Cache::get('purchaseHistoryRanking'));
-        // }
+        if (Cache::has('purchaseHistoryRanking')) {
+            return json_encode(Cache::get('purchaseHistoryRanking'));
+        }
 
         $ranking = $this->purchaseHistory->purchaseHistoryRanking();
-        // Cache::put('purchaseHistoryRanking', $ranking);
+        Cache::put('purchaseHistoryRanking', $ranking);
 
         return json_encode($ranking);
     }
@@ -46,6 +46,7 @@ class GoodRankingController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
+     * @todo 現在どこからも呼ばれていないアクションです。 テーブルにカラム追加後このapiをコールする予定です
      */
     public function goodRankingByCategory(Request $request)
     {

--- a/ec/app/Http/Controllers/GoodRankingController.php
+++ b/ec/app/Http/Controllers/GoodRankingController.php
@@ -4,29 +4,58 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use App\purchaseHistory;
 
+/**
+ * GoodRankingController
+ */
 class GoodRankingController extends Controller
 {
     private $purchaseHistory;
 
-    public function __construct(\App\purchaseHistory $purchaseHistory)
+    /**
+     * __construct
+     *
+     * @param purchaseHistory $purchaseHistory
+     */
+    public function __construct(purchaseHistory $purchaseHistory)
     {
         $this->purchaseHistory = $purchaseHistory;
     }
 
     /**
-     * Handle the incoming request.
+     * 商品ランキング
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function goodRanking()
+    {
+        // 商品ランキングを返します
+        // if (Cache::has('purchaseHistoryRanking')) {
+        //     return json_encode(Cache::get('purchaseHistoryRanking'));
+        // }
+
+        $ranking = $this->purchaseHistory->purchaseHistoryRanking();
+        // Cache::put('purchaseHistoryRanking', $ranking);
+
+        return json_encode($ranking);
+    }
+
+    /**
+     * カテゴリ別商品ランキング
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function __invoke()
+    public function goodRankingByCategory(Request $request)
     {
-        // 商品ランキングを返します
-        if (Cache::has('purchaseHistoryRanking')) return json_encode(Cache::get('purchaseHistoryRanking'));
+        // カテゴリ別商品ランキングを返します
+        if (Cache::has('purchaseHistoryRankingByCategory')) {
+            return json_encode(Cache::get('purchaseHistoryRankingByCategory'));
+        }
 
-        $ranking = $this->purchaseHistory->purchaseHistoryRanking();
-        Cache::put('purchaseHistoryRanking', $ranking);
+        $ranking = $this->purchaseHistory->purchaseHistoryRankingByCategory();
+        Cache::put('purchaseHistoryRankingByCategory', $ranking);
 
         return json_encode($ranking);
     }

--- a/ec/app/Http/Controllers/GoodRankingController.php
+++ b/ec/app/Http/Controllers/GoodRankingController.php
@@ -54,7 +54,7 @@ class GoodRankingController extends Controller
             return json_encode(Cache::get('purchaseHistoryRankingByCategory'));
         }
 
-        $ranking = $this->purchaseHistory->purchaseHistoryRankingByCategory();
+        $ranking = $this->purchaseHistory->purchaseHistoryRankingByCategory($request->categoryId);
         Cache::put('purchaseHistoryRankingByCategory', $ranking);
 
         return json_encode($ranking);

--- a/ec/app/PurchaseHistory.php
+++ b/ec/app/PurchaseHistory.php
@@ -22,6 +22,7 @@ class PurchaseHistory extends Model
 
     /**
      * ログインしているユーザーの購入履歴を取得し返します。
+     * 
      * @param int $userId
      * @param string|array リレーションデータの Eager Loadingするために指定する、初期値はgood。複数指定する場合は配列で指定
      * @return array 購入履歴
@@ -33,6 +34,7 @@ class PurchaseHistory extends Model
 
     /**
      * 購入履歴を登録する
+     * 
      * @param array $items 購入した商品
      * @param int $userId ログインしているユーザーid
      */

--- a/ec/app/PurchaseHistory.php
+++ b/ec/app/PurchaseHistory.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 
 class PurchaseHistory extends Model
@@ -45,11 +47,35 @@ class PurchaseHistory extends Model
 
     /**
      * 購入履歴から最も多く購入されている商品ランキングを15件取得して返す
+     * 
      * @return collection ランキング結果のコレクション、purchase_historiesにレコードがなければ空のコレクション
      */
     public function purchaseHistoryRanking($withTables = 'good')
     {
-        return $this::with($withTables)->select(\DB::raw('count(*) as purchase_history_count, good_id'))
+        return $this::with($withTables)->select(DB::raw('count(*) as purchase_history_count, good_id'))
+        ->groupBy('good_id')
+        ->orderBy('purchase_history_count', 'DESC')
+        ->limit(15)
+        ->get();
+    }
+
+    /**
+     * 購入履歴から最も多く購入されている商品ランキングを15件取得して返す
+     * 
+     * categoryIdがnullまたはDBに一つも合致するものがなければ空のコレクションを返します。
+     *
+     * @param string|null $categoryId 取得したいランキングのカテゴリID
+     * @return collection ランキング結果のコレクション
+     */
+    public function purchaseHistoryRankingByCategory(?string $categoryId, $withTables = 'good')
+    {
+        if (is_null($categoryId)) {
+            return new Collection;
+        }
+
+        return $this::with($withTables)
+        ->where('category_id', $categoryId)
+        ->select(DB::raw('count(*) as purchase_history_count, good_id'))
         ->groupBy('good_id')
         ->orderBy('purchase_history_count', 'DESC')
         ->limit(15)

--- a/ec/routes/api.php
+++ b/ec/routes/api.php
@@ -17,4 +17,4 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('goodsRanking', 'GoodRankingController'); // 商品ランキングapi
+Route::get('goodsRanking', 'GoodRankingController@goodRanking'); // 商品ランキングapi

--- a/ec/tests/Unit/PurchaseHistoryTest.php
+++ b/ec/tests/Unit/PurchaseHistoryTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\PurchaseHistory;
 
@@ -46,4 +45,6 @@ class PurchaseHistoryTest extends TestCase
 
         $this->assertDatabaseHas('purchase_histories', $this->createArr);
     }
+
+    // TODO DB purchese_historiesにcategory_idカラムを追加したらpurchaseHistoryRankingByCategoryをテストする
 }


### PR DESCRIPTION
商品ランキング機能をカテゴリ別のランキングを書いたけど、
よく見たらpurchase_historiesテーブルにcategory_idカラムがなかった。。。
DBに絡むが追加されたら動くように書いては見たけど、テストできないのでどこからも使っていない。
テーブルにカラムを追加したらテストしたら、このapiをコールする予定。